### PR TITLE
docs: add SSE and Graceful Shutdown documentation pages

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
             { text: 'Decorators', link: '/api/decorators' },
             { text: 'Controllers', link: '/api/controllers' },
             { text: 'Services', link: '/api/services' },
+            { text: 'Graceful Shutdown & Lifecycle', link: '/api/graceful-shutdown' },
             { text: 'Validation', link: '/api/validation' },
           ],
         },
@@ -70,6 +71,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: 'WebSocket Gateway', link: '/api/websocket' },
+            { text: 'SSE (Server-Sent Events)', link: '/api/sse' },
             { text: 'HTTP Client', link: '/api/requests' },
             { text: 'API Documentation (OpenAPI)', link: '/api/docs' },
           ],

--- a/docs/api/controllers.md
+++ b/docs/api/controllers.md
@@ -44,6 +44,12 @@ export class Controller {
 
   /** Create text response */
   protected text(data: string, status?: number): Response;
+
+  /** Create SSE (Server-Sent Events) response — see [SSE API](/api/sse) for details */
+  protected sse(
+    source: AsyncIterable<SseEvent | unknown> | ((signal: AbortSignal) => AsyncIterable<SseEvent | unknown>),
+    options?: SseOptions,
+  ): Response;
 }
 ```
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -313,6 +313,8 @@ await userService.sendScheduledEmails();
 
 ### Graceful Shutdown
 
+> **See also:** [Graceful Shutdown & Lifecycle](/api/graceful-shutdown) for the full shutdown sequence, all 5 lifecycle hook interfaces with examples, and configuration patterns.
+
 OneBun enables graceful shutdown **by default**. When the application receives SIGTERM or SIGINT signals, it automatically:
 1. Calls `beforeApplicationDestroy(signal)` hooks on all services and controllers
 2. Stops the HTTP server

--- a/docs/api/graceful-shutdown.md
+++ b/docs/api/graceful-shutdown.md
@@ -1,0 +1,393 @@
+---
+description: "Graceful shutdown, lifecycle hooks (OnModuleInit, OnApplicationInit, OnModuleDestroy, BeforeApplicationDestroy, OnApplicationDestroy), signal handling, shutdown sequence."
+---
+
+<llm-only>
+
+## Quick Reference for AI
+
+**Graceful shutdown is enabled by default.** SIGTERM/SIGINT triggers the full shutdown sequence.
+
+**Shutdown sequence (in order):**
+1. `beforeApplicationDestroy(signal)` hooks
+2. WebSocket cleanup
+3. Queue service stop + adapter disconnect
+4. HTTP server stop
+5. `onModuleDestroy()` hooks
+6. Shared Redis disconnect
+7. `onApplicationDestroy(signal)` hooks
+
+**5 lifecycle hook interfaces:**
+```typescript
+implements OnModuleInit           // after DI, before HTTP start
+implements OnApplicationInit      // after all modules, before HTTP start
+implements OnModuleDestroy        // during shutdown, after HTTP stops
+implements BeforeApplicationDestroy  // start of shutdown
+implements OnApplicationDestroy      // end of shutdown (final cleanup)
+```
+
+**Disable/enable:**
+```typescript
+// Disable automatic shutdown handling
+const app = new OneBunApplication(AppModule, { gracefulShutdown: false });
+
+// Enable manually later
+app.enableGracefulShutdown();
+
+// Programmatic shutdown
+await app.stop();
+await app.stop({ closeSharedRedis: false, signal: 'SIGTERM' });
+```
+
+**Imports:**
+```typescript
+import { type OnModuleInit, type OnApplicationInit, type OnModuleDestroy, type BeforeApplicationDestroy, type OnApplicationDestroy } from '@onebun/core';
+```
+
+</llm-only>
+
+# Graceful Shutdown & Lifecycle
+
+Package: `@onebun/core`
+
+## Overview
+
+OneBun enables graceful shutdown **by default**. When the application receives a SIGTERM or SIGINT signal, it runs a deterministic shutdown sequence — closing connections, flushing buffers, and calling lifecycle hooks in a defined order.
+
+This page covers:
+- The full shutdown sequence
+- All 5 lifecycle hook interfaces with practical examples
+- Configuration options (disable, programmatic shutdown)
+- Patterns for database connections, caches, and background tasks
+
+## Shutdown Sequence
+
+When a shutdown signal is received (or `app.stop()` is called), the following steps execute in order:
+
+| Step | What happens |
+|------|-------------|
+| 1. **`beforeApplicationDestroy(signal)`** | All services/controllers implementing `BeforeApplicationDestroy` are notified. Use this to stop accepting new work and flush buffers. |
+| 2. **WebSocket cleanup** | All WebSocket connections are closed gracefully. |
+| 3. **Queue service stop** | Queue subscribers stop consuming; queue adapter disconnects. |
+| 4. **HTTP server stop** | Bun HTTP server stops accepting new connections. In-flight requests complete. |
+| 5. **`onModuleDestroy()`** | All services/controllers implementing `OnModuleDestroy` are called. Close database connections, release resources. |
+| 6. **Shared Redis disconnect** | The shared Redis connection pool (used by Cache, WebSocket, Queue) is closed. |
+| 7. **`onApplicationDestroy(signal)`** | Final cleanup hooks. Flush metrics, send shutdown notifications, etc. |
+
+> **Startup hooks** (`onModuleInit`, `onApplicationInit`) run in dependency order during application bootstrap, before the HTTP server starts.
+
+## Lifecycle Hooks
+
+OneBun provides five lifecycle hook interfaces. Implement them on any service or controller to hook into specific points of the application lifecycle.
+
+### OnModuleInit
+
+Called after the service/controller is instantiated and all dependencies are injected. Runs **before** the HTTP server starts. Called sequentially in dependency order.
+
+```typescript
+import { Service, BaseService, type OnModuleInit } from '@onebun/core';
+
+@Service()
+export class DatabaseService extends BaseService implements OnModuleInit {
+  private pool: DatabasePool;
+
+  async onModuleInit() {
+    this.pool = await createPool({
+      host: this.config.get('db.host'),
+      port: this.config.get('db.port'),
+    });
+    await this.pool.connect();
+    this.logger.info('Database pool connected');
+  }
+}
+```
+
+**Use for:** establishing connections, initializing clients, loading configuration.
+
+### OnApplicationInit
+
+Called after **all** modules are initialized, but **before** the HTTP server starts listening. Use for application-wide setup that depends on all services being ready.
+
+```typescript
+import { Service, BaseService, type OnApplicationInit } from '@onebun/core';
+
+@Service()
+export class StartupService extends BaseService implements OnApplicationInit {
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly cache: CacheService,
+  ) {
+    super();
+  }
+
+  async onApplicationInit() {
+    // Seed default data if empty
+    const count = await this.db.getUserCount();
+    if (count === 0) {
+      await this.db.seedDefaultUsers();
+      this.logger.info('Seeded default users');
+    }
+
+    // Warm frequently-accessed caches
+    const settings = await this.db.getAllSettings();
+    await this.cache.set('app:settings', settings, { ttl: 3600000 });
+    this.logger.info('Cache warmed');
+  }
+}
+```
+
+**Use for:** seeding data, warming caches, running migrations, health checks.
+
+### OnModuleDestroy
+
+Called during shutdown, **after** the HTTP server stops. Use to close connections and release resources.
+
+```typescript
+import { Service, BaseService, type OnModuleDestroy } from '@onebun/core';
+
+@Service()
+export class DatabaseService extends BaseService implements OnModuleDestroy {
+  private pool: DatabasePool;
+
+  async onModuleDestroy() {
+    await this.pool.end();
+    this.logger.info('Database pool closed');
+  }
+}
+```
+
+**Use for:** closing database connections, releasing file handles, stopping background timers.
+
+### BeforeApplicationDestroy
+
+Called at the **very start** of the shutdown process, before anything else is torn down. The signal that triggered shutdown is passed as an argument.
+
+```typescript
+import { Service, BaseService, type BeforeApplicationDestroy } from '@onebun/core';
+
+@Service()
+export class WorkerService extends BaseService implements BeforeApplicationDestroy {
+  private accepting = true;
+
+  async beforeApplicationDestroy(signal?: string) {
+    this.logger.info(`Shutdown initiated by ${signal}, stopping worker`);
+
+    // Stop accepting new work
+    this.accepting = false;
+
+    // Wait for in-progress jobs to finish (up to 10s)
+    await this.drainQueue(10000);
+
+    // Flush any buffered results
+    await this.resultBuffer.flush();
+  }
+
+  canAcceptWork(): boolean {
+    return this.accepting;
+  }
+}
+```
+
+**Use for:** stop accepting new work, drain queues, flush write buffers, mark instance as unhealthy in service discovery.
+
+### OnApplicationDestroy
+
+Called at the **very end** of the shutdown process, after everything else (HTTP server, Redis, etc.) has been closed. The signal is passed as an argument.
+
+```typescript
+import { Service, BaseService, type OnApplicationDestroy } from '@onebun/core';
+
+@Service()
+export class TelemetryService extends BaseService implements OnApplicationDestroy {
+  async onApplicationDestroy(signal?: string) {
+    // Final metrics flush
+    await this.metricsExporter.flush();
+
+    // Send shutdown notification
+    await this.alerting.notify({
+      level: 'info',
+      message: `Service shut down (${signal})`,
+      timestamp: Date.now(),
+    });
+
+    this.logger.info('Telemetry flushed, goodbye');
+  }
+}
+```
+
+**Use for:** final metrics/traces flush, shutdown notifications, audit logging.
+
+### Hook execution order summary
+
+| Phase | Hook | Signal arg? |
+|-------|------|-------------|
+| **Startup** | `onModuleInit()` | No |
+| **Startup** | `onApplicationInit()` | No |
+| **Shutdown** | `beforeApplicationDestroy(signal?)` | Yes |
+| **Shutdown** | `onModuleDestroy()` | No |
+| **Shutdown** | `onApplicationDestroy(signal?)` | Yes |
+
+## Configuration
+
+### Default behavior
+
+Graceful shutdown is enabled by default. No configuration needed:
+
+```typescript
+const app = new OneBunApplication(AppModule);
+await app.start();
+// SIGTERM/SIGINT handlers are automatically registered
+```
+
+### Disabling automatic shutdown
+
+```typescript
+const app = new OneBunApplication(AppModule, {
+  gracefulShutdown: false,
+});
+await app.start();
+```
+
+### Enabling manually
+
+After disabling, you can re-enable at any point:
+
+```typescript
+const app = new OneBunApplication(AppModule, {
+  gracefulShutdown: false,
+});
+await app.start();
+
+// Later: enable signal handlers
+app.enableGracefulShutdown();
+```
+
+### Programmatic shutdown
+
+Call `app.stop()` directly to trigger the shutdown sequence:
+
+```typescript
+// Full shutdown (closes everything including shared Redis)
+await app.stop();
+
+// Keep shared Redis open (other consumers may still need it)
+await app.stop({ closeSharedRedis: false });
+
+// Pass a signal name for lifecycle hooks
+await app.stop({ signal: 'SIGTERM' });
+```
+
+#### stop() options
+
+```typescript
+interface StopOptions {
+  /** Close the shared Redis connection pool. Default: true */
+  closeSharedRedis?: boolean;
+  /** Signal name passed to lifecycle hooks. E.g. 'SIGTERM', 'SIGINT' */
+  signal?: string;
+}
+```
+
+## Examples
+
+### Database service with full lifecycle
+
+```typescript
+import {
+  Service,
+  BaseService,
+  type OnModuleInit,
+  type OnModuleDestroy,
+  type BeforeApplicationDestroy,
+} from '@onebun/core';
+
+@Service()
+export class DatabaseService extends BaseService
+  implements OnModuleInit, OnModuleDestroy, BeforeApplicationDestroy
+{
+  private pool: DatabasePool;
+  private healthy = false;
+
+  async onModuleInit() {
+    this.pool = await createPool(this.config.get('db'));
+    await this.pool.connect();
+    this.healthy = true;
+    this.logger.info('Database connected');
+  }
+
+  async beforeApplicationDestroy(signal?: string) {
+    // Mark unhealthy so health checks fail → load balancer stops routing
+    this.healthy = false;
+    this.logger.info(`Database marked unhealthy (${signal})`);
+  }
+
+  async onModuleDestroy() {
+    await this.pool.end();
+    this.logger.info('Database pool closed');
+  }
+
+  isHealthy(): boolean {
+    return this.healthy;
+  }
+}
+```
+
+### Custom shutdown handler
+
+```typescript
+import { OneBunApplication } from '@onebun/core';
+import { AppModule } from './app.module';
+
+const app = new OneBunApplication(AppModule, {
+  gracefulShutdown: false, // We'll handle it ourselves
+});
+
+await app.start();
+
+// Custom signal handling with timeout
+const shutdown = async (signal: string) => {
+  console.log(`Received ${signal}, shutting down...`);
+
+  const timeout = setTimeout(() => {
+    console.error('Shutdown timed out, forcing exit');
+    process.exit(1);
+  }, 30000);
+
+  try {
+    await app.stop({ signal });
+    clearTimeout(timeout);
+    console.log('Clean shutdown complete');
+    process.exit(0);
+  } catch (err) {
+    console.error('Shutdown error:', err);
+    clearTimeout(timeout);
+    process.exit(1);
+  }
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+```
+
+### Programmatic shutdown (e.g. from admin endpoint)
+
+```typescript
+import { Controller, Post, type OneBunApplication } from '@onebun/core';
+
+@Controller('/admin')
+class AdminController {
+  constructor(private readonly app: OneBunApplication) {}
+
+  @Post('/shutdown')
+  async shutdown() {
+    // Respond first, then shut down
+    setTimeout(() => this.app.stop({ signal: 'admin-request' }), 100);
+    return this.success({ message: 'Shutting down...' });
+  }
+}
+```
+
+## See Also
+
+- [Core API — OneBunApplication](/api/core) — application bootstrap and options
+- [Services API — Lifecycle Hooks](/api/services#lifecycle-hooks) — detailed service lifecycle examples

--- a/docs/api/sse.md
+++ b/docs/api/sse.md
@@ -1,0 +1,510 @@
+---
+description: "SSE (Server-Sent Events) support — @Sse() decorator, Controller.sse() programmatic API, SseEvent interface, heartbeat, proxy pattern."
+---
+
+<llm-only>
+
+## Quick Reference for AI
+
+**Two patterns for SSE in OneBun:**
+
+1. **@Sse() decorator** — mark an async generator method; framework handles Response creation
+2. **Controller.sse()** — programmatic; call from any route handler, returns a Response
+
+**Decorator pattern (preferred for simple cases):**
+```typescript
+@Get('/events')
+@Sse()
+async *events(): SseGenerator {
+  yield { event: 'ping', data: { ts: Date.now() } };
+}
+```
+
+**Programmatic pattern (for dynamic sources, proxying):**
+```typescript
+@Get('/events')
+events(): Response {
+  return this.sse(this.generateEvents());
+}
+
+// With AbortSignal for proxying:
+@Get('/proxy')
+proxy(): Response {
+  return this.sse((signal) => this.upstream(signal));
+}
+```
+
+**SseEvent interface:**
+```typescript
+interface SseEvent {
+  event?: string;   // event name (default: 'message')
+  data: unknown;    // JSON-serialized payload
+  id?: string;      // reconnection ID (Last-Event-ID)
+  retry?: number;   // reconnection interval (ms)
+}
+```
+
+**Key types:** `SseGenerator`, `SseOptions` (`heartbeat`, `onAbort`), `SseDecoratorOptions` (`heartbeat`, `timeout`)
+
+**Helper functions:** `formatSseEvent(event)`, `createSseStream(source, options)`
+
+**Constants:** `DEFAULT_SSE_HEARTBEAT_MS` = 30000, `DEFAULT_SSE_TIMEOUT` = 600, `DEFAULT_IDLE_TIMEOUT` = 120
+
+**Imports:**
+```typescript
+import { Sse, type SseGenerator, type SseEvent, type SseOptions, formatSseEvent, createSseStream, DEFAULT_SSE_HEARTBEAT_MS, DEFAULT_SSE_TIMEOUT } from '@onebun/core';
+```
+
+</llm-only>
+
+# SSE (Server-Sent Events) API
+
+Package: `@onebun/core`
+
+## Overview
+
+OneBun provides built-in support for [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) (SSE) — a standard for streaming real-time updates from server to client over HTTP.
+
+Two patterns are available:
+
+- **`@Sse()` decorator** — annotate an async generator method. The framework automatically creates the SSE response with correct headers, heartbeat, and timeout.
+- **`Controller.sse()` method** — programmatic API for when you need more control. Call it from any route handler and get a `Response` back.
+
+Both patterns produce the same wire format (`text/event-stream`) and support heartbeat keep-alive, client disconnect detection, and cleanup.
+
+## Quick Start
+
+Minimal SSE endpoint using the `@Sse()` decorator:
+
+```typescript
+import { Controller, Module, Get, Sse, type SseGenerator } from '@onebun/core';
+
+@Controller('/api')
+class EventController {
+  @Get('/events')
+  @Sse()
+  async *events(): SseGenerator {
+    yield { event: 'connected', data: { timestamp: Date.now() } };
+
+    for (let i = 0; i < 10; i++) {
+      await Bun.sleep(1000);
+      yield { event: 'tick', data: { count: i } };
+    }
+
+    yield { event: 'done', data: { total: 10 } };
+  }
+}
+
+@Module({ controllers: [EventController] })
+export class AppModule {}
+```
+
+The framework sets the response headers (`Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`) and starts streaming events as the generator yields them.
+
+## SseEvent Interface
+
+Each yielded value can be an `SseEvent` object or raw data. Raw data is wrapped in a default `data:` frame automatically.
+
+```typescript
+interface SseEvent {
+  /** Event name (optional, defaults to 'message') */
+  event?: string;
+  /** Event data (will be JSON serialized) */
+  data: unknown;
+  /** Event ID for reconnection (Last-Event-ID header) */
+  id?: string;
+  /** Reconnection interval in milliseconds */
+  retry?: number;
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event` | `string?` | Event name. Clients filter on this via `EventSource.addEventListener(name, ...)`. Omit for the default `message` event. |
+| `data` | `unknown` | Payload. Strings are sent as-is; everything else is `JSON.stringify()`-ed. Multi-line data is split into multiple `data:` lines per the SSE spec. |
+| `id` | `string?` | Sets the `Last-Event-ID` on the client. On reconnect, the browser sends this back via the `Last-Event-ID` header so you can resume. |
+| `retry` | `number?` | Tells the client how many milliseconds to wait before reconnecting after a disconnect. |
+
+### Wire format examples
+
+```typescript
+// Named event with ID
+yield { event: 'update', data: { count: 42 }, id: '123' };
+// Wire: event: update\nid: 123\ndata: {"count":42}\n\n
+
+// Simple data (no event name → default 'message' event)
+yield { data: { message: 'Hello' } };
+// Wire: data: {"message":"Hello"}\n\n
+
+// Raw data (not an SseEvent object)
+yield { message: 'Hello' };
+// Wire: data: {"message":"Hello"}\n\n
+
+// With retry
+yield { event: 'status', data: { online: true }, retry: 5000 };
+// Wire: event: status\nretry: 5000\ndata: {"online":true}\n\n
+```
+
+## @Sse() Decorator
+
+Marks a controller method as an SSE endpoint. The method must be an async generator that yields `SseEvent` objects (or raw data).
+
+```typescript
+import { Get, Sse, type SseGenerator } from '@onebun/core';
+
+@Get('/events')
+@Sse()
+async *events(): SseGenerator {
+  // yield events...
+}
+```
+
+### SseDecoratorOptions
+
+```typescript
+interface SseDecoratorOptions {
+  /**
+   * Heartbeat interval in milliseconds.
+   * Sends a comment (": heartbeat\n\n") at this interval to keep the connection alive.
+   * @defaultValue 30000 (30 seconds)
+   */
+  heartbeat?: number;
+
+  /**
+   * Per-request idle timeout in seconds for this SSE connection.
+   * Overrides the global `idleTimeout` from ApplicationOptions.
+   * Set to 0 to disable the timeout entirely.
+   * @defaultValue 600 (10 minutes)
+   */
+  timeout?: number;
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `heartbeat` | `number?` | `30000` (30s) | Interval in ms between heartbeat comments. Prevents proxies/load balancers from closing idle connections. |
+| `timeout` | `number?` | `600` (10min) | Per-request idle timeout in seconds. SSE connections are long-lived, so they get a longer timeout than regular HTTP requests (default 120s). Set to `0` to disable. |
+
+### Examples
+
+```typescript
+// Default: 30s heartbeat, 10min timeout
+@Get('/events')
+@Sse()
+async *events(): SseGenerator { /* ... */ }
+
+// Custom heartbeat (15s) for aggressive proxies
+@Get('/live')
+@Sse({ heartbeat: 15000 })
+async *liveUpdates(): SseGenerator { /* ... */ }
+
+// Long-running stream with no timeout
+@Get('/stream')
+@Sse({ heartbeat: 30000, timeout: 0 })
+async *infiniteStream(): SseGenerator { /* ... */ }
+```
+
+## Controller.sse() Method
+
+The programmatic API for SSE. Available on all controllers that extend `BaseController`. Returns a `Response` object — use it when the `@Sse()` decorator doesn't fit (dynamic sources, SSE proxying, conditional streaming).
+
+### Signatures
+
+```typescript
+// Basic: pass an async iterable
+protected sse(source: AsyncIterable<SseEvent | unknown>, options?: SseOptions): Response;
+
+// Factory: receive an AbortSignal, return an async iterable
+protected sse(
+  source: (signal: AbortSignal) => AsyncIterable<SseEvent | unknown>,
+  options?: SseOptions
+): Response;
+```
+
+### SseOptions
+
+```typescript
+interface SseOptions {
+  /**
+   * Heartbeat interval in milliseconds.
+   * Sends a comment (": heartbeat\n\n") at this interval.
+   */
+  heartbeat?: number;
+
+  /**
+   * Callback invoked when the client disconnects or aborts the SSE connection.
+   * Useful for cleanup logic (unsubscribe, release resources).
+   *
+   * For @Sse() decorator usage, prefer try/finally in the generator instead.
+   */
+  onAbort?: () => void;
+}
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `heartbeat` | `number?` | Heartbeat interval in ms (no default — set explicitly if needed) |
+| `onAbort` | `() => void` | Called when the client disconnects. Use for cleanup when you can't use `try/finally` in the generator. |
+
+### Usage examples
+
+```typescript
+import { Controller, Get, type SseEvent, type SseGenerator } from '@onebun/core';
+
+@Controller('/api')
+class StreamController {
+  // Basic: pass an async generator directly
+  @Get('/events')
+  events(): Response {
+    return this.sse(this.generateEvents());
+  }
+
+  // With options: heartbeat + cleanup callback
+  @Get('/live')
+  live(): Response {
+    const subscription = this.dataService.subscribe();
+    return this.sse(subscription, {
+      heartbeat: 15000,
+      onAbort: () => this.dataService.unsubscribe(subscription),
+    });
+  }
+
+  // Factory pattern: AbortSignal for upstream proxying
+  @Get('/proxy')
+  proxy(): Response {
+    return this.sse((signal) => this.proxyUpstream(signal));
+  }
+
+  private async *generateEvents(): SseGenerator {
+    for (let i = 0; i < 10; i++) {
+      await Bun.sleep(1000);
+      yield { event: 'tick', data: { count: i } };
+    }
+  }
+
+  private async *proxyUpstream(signal: AbortSignal): SseGenerator {
+    // When the client disconnects, signal is aborted → fetch is cancelled
+    const response = await fetch('https://api.example.com/events', { signal });
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        const text = decoder.decode(value);
+        // Parse and re-emit SSE events from upstream
+        yield { event: 'upstream', data: text };
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}
+```
+
+## SseGenerator Type
+
+The return type for `@Sse()`-decorated async generator methods:
+
+```typescript
+type SseGenerator = AsyncGenerator<SseEvent | unknown, void, unknown>;
+```
+
+Yields `SseEvent` objects for structured events, or any other value (which gets JSON-serialized as a default `data:` frame).
+
+## Helper Functions
+
+OneBun exports two helper functions for advanced use cases (custom middleware, non-controller SSE, etc.):
+
+### formatSseEvent()
+
+Converts an event object into SSE wire format (the `event:`, `id:`, `retry:`, `data:` text protocol).
+
+```typescript
+import { formatSseEvent } from '@onebun/core';
+
+formatSseEvent({ event: 'update', data: { count: 1 }, id: '123' });
+// Returns: "event: update\nid: 123\ndata: {\"count\":1}\n\n"
+
+formatSseEvent({ count: 1 });
+// Returns: "data: {\"count\":1}\n\n"
+```
+
+### createSseStream()
+
+Creates a `ReadableStream<Uint8Array>` from an async iterable. This is what `Controller.sse()` uses internally. Use it when you need to build the `Response` yourself.
+
+```typescript
+import { createSseStream, type SseEvent } from '@onebun/core';
+
+async function* myEvents(): AsyncGenerator<SseEvent> {
+  yield { event: 'hello', data: { msg: 'world' } };
+}
+
+const stream = createSseStream(myEvents(), { heartbeat: 30000 });
+const response = new Response(stream, {
+  headers: {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  },
+});
+```
+
+## Constants
+
+```typescript
+import {
+  DEFAULT_SSE_HEARTBEAT_MS,
+  DEFAULT_SSE_TIMEOUT,
+  DEFAULT_IDLE_TIMEOUT,
+} from '@onebun/core';
+```
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `DEFAULT_SSE_HEARTBEAT_MS` | `30000` (30s) | Default heartbeat interval for `@Sse()` decorator |
+| `DEFAULT_SSE_TIMEOUT` | `600` (10min) | Default idle timeout for SSE connections (seconds) |
+| `DEFAULT_IDLE_TIMEOUT` | `120` (2min) | Default idle timeout for regular HTTP connections (seconds) |
+
+## Examples
+
+### Basic event stream
+
+```typescript
+@Get('/notifications')
+@Sse()
+async *notifications(): SseGenerator {
+  while (true) {
+    const notification = await this.notificationService.waitForNext();
+    yield {
+      event: 'notification',
+      data: notification,
+      id: notification.id,
+    };
+  }
+}
+```
+
+### Named events with IDs
+
+```typescript
+@Get('/updates')
+@Sse()
+async *updates(): SseGenerator {
+  let counter = 0;
+
+  yield { event: 'init', data: { version: '1.0' }, id: String(counter++) };
+
+  for await (const update of this.updateService.stream()) {
+    yield {
+      event: update.type,  // 'create', 'update', 'delete'
+      data: update.payload,
+      id: String(counter++),
+    };
+  }
+}
+```
+
+### Heartbeat configuration
+
+```typescript
+// Aggressive heartbeat for environments behind Cloudflare/nginx with short timeouts
+@Get('/live')
+@Sse({ heartbeat: 10000, timeout: 0 })
+async *liveData(): SseGenerator {
+  for await (const data of this.dataService.subscribe()) {
+    yield { event: 'data', data };
+  }
+}
+```
+
+### SSE proxy / relay pattern
+
+Forward events from an upstream SSE source to clients. The factory pattern with `AbortSignal` ensures the upstream connection is cleaned up when the client disconnects.
+
+```typescript
+@Get('/relay')
+relay(): Response {
+  return this.sse((signal) => this.relayUpstream(signal));
+}
+
+private async *relayUpstream(signal: AbortSignal): SseGenerator {
+  const upstream = await fetch('https://api.example.com/stream', { signal });
+  const reader = upstream.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const events = buffer.split('\n\n');
+      buffer = events.pop()!; // keep incomplete event in buffer
+
+      for (const raw of events) {
+        if (!raw.trim()) continue;
+        yield { event: 'relayed', data: raw };
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+```
+
+### Cleanup with try/finally in generators
+
+For `@Sse()` decorator usage, use `try/finally` in the generator for cleanup instead of `onAbort`:
+
+```typescript
+@Get('/stream')
+@Sse({ heartbeat: 15000 })
+async *stream(): SseGenerator {
+  const subscription = this.pubsub.subscribe('events');
+
+  try {
+    for await (const event of subscription) {
+      yield { event: 'update', data: event };
+    }
+  } finally {
+    // Always runs: generator completes OR client disconnects
+    await this.pubsub.unsubscribe(subscription);
+    this.logger.info('SSE client disconnected, cleaned up subscription');
+  }
+}
+```
+
+## Client-Side Usage
+
+SSE is consumed via the standard [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) API:
+
+```typescript
+const source = new EventSource('/api/events');
+
+// Default 'message' events (no event name in SseEvent)
+source.onmessage = (e) => {
+  console.log('Data:', JSON.parse(e.data));
+};
+
+// Named events
+source.addEventListener('notification', (e) => {
+  const notification = JSON.parse(e.data);
+  console.log('Notification:', notification);
+});
+
+// Connection lifecycle
+source.onopen = () => console.log('Connected');
+source.onerror = (e) => {
+  console.error('SSE error:', e);
+  // EventSource automatically reconnects
+};
+
+// Clean up when done
+source.close();
+```
+
+> **Reconnection:** `EventSource` automatically reconnects on disconnect. If your events include `id` fields, the browser sends the last ID via `Last-Event-ID` header on reconnect — use this to resume the stream from where the client left off.

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,7 +17,8 @@ production-grade backend services.
 - **HTTP Routing**: Decorator-based (@Get, @Post, @Put, @Delete, @Patch) with path params, query, body, headers
 - **Guards**: Custom route guards for authentication/authorization
 - **Middleware**: @UseMiddleware decorator with chaining support
-- **Graceful Shutdown**: Enabled by default, handles SIGTERM/SIGINT
+- **SSE**: Server-Sent Events via @Sse() decorator or Controller.sse() programmatic API
+- **Graceful Shutdown**: Enabled by default, handles SIGTERM/SIGINT with 5 lifecycle hooks
 
 ### WebSocket
 - WebSocket Gateway with @WebSocketGateway, @SubscribeMessage decorators
@@ -140,6 +141,12 @@ rooms, namespaces, and broadcasting.
 Auto-generated typed client for type-safe frontend ↔ backend
 WebSocket communication.
 → [API Reference](/api/websocket)
+
+### SSE (Server-Sent Events)
+Built-in SSE support with two patterns: `@Sse()` decorator for async generators
+and `Controller.sse()` for programmatic usage. Automatic heartbeat keep-alive,
+client disconnect detection, and SSE proxy/relay support with `AbortSignal`.
+→ [API Reference](/api/sse)
 
 ## Microservices (@onebun/core)
 


### PR DESCRIPTION
Addresses issue #2

## Changes

### New Pages
- **docs/api/sse.md** — Full SSE documentation:
  - `<llm-only>` quick reference section
  - Overview of two SSE patterns (decorator and programmatic)
  - Quick Start example
  - SseEvent interface with wire format examples
  - @Sse() decorator and SseDecoratorOptions
  - Controller.sse() method with all three signatures
  - SseGenerator type and SseOptions
  - Helper functions: formatSseEvent(), createSseStream()
  - Constants: DEFAULT_SSE_HEARTBEAT_MS, DEFAULT_SSE_TIMEOUT, DEFAULT_IDLE_TIMEOUT
  - Examples: basic stream, named events with IDs, heartbeat config, SSE proxy/relay, try/finally cleanup
  - Client-side EventSource usage

- **docs/api/graceful-shutdown.md** — Full lifecycle documentation:
  - `<llm-only>` quick reference section
  - Shutdown sequence (7 ordered steps)
  - All 5 lifecycle hook interfaces with practical examples (OnModuleInit, OnApplicationInit, OnModuleDestroy, BeforeApplicationDestroy, OnApplicationDestroy)
  - Hook execution order summary
  - Configuration: default behavior, disabling, manual enable, programmatic shutdown with StopOptions
  - Examples: database service with full lifecycle, custom shutdown handler, programmatic shutdown from admin endpoint

### Sidebar & Cross-references
- **config.mts**: Added SSE to Communication section (after WebSocket Gateway), Graceful Shutdown to Core Framework section (after Services)
- **features.md**: Added SSE subsection with link to /api/sse
- **core.md**: Added cross-reference link to dedicated /api/graceful-shutdown page
- **controllers.md**: SSE section already references /api/sse

### Notes
- All types and constants verified against source code (types.ts, decorators.ts, controller.ts, lifecycle.ts)
- Follows existing documentation patterns from websocket.md and queue.md
- Includes frontmatter with description for SEO
- Docs build could not be verified in CI sandbox (no bun runtime), but VitePress markdown is standard